### PR TITLE
Fix post-build events to support paths with spaces

### DIFF
--- a/Application/LunarLambda.csproj
+++ b/Application/LunarLambda.csproj
@@ -173,14 +173,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "$(OS)" == "Windows_NT"  if "$(ConfigurationName)" == "Debug" if exist $(SolutionDir)_bin_debug copy $(TargetDir)*.exe $(SolutionDir)_bin_debug
-if "$(OS)" == "Windows_NT"  if "$(ConfigurationName)" == "Debug" if exist $(SolutionDir)_bin_debug copy $(TargetDir)*.dll $(SolutionDir)_bin_debug
-if "$(OS)" == "Windows_NT"  if "$(ConfigurationName)" == "Release" if exist $(SolutionDir)_bin_release copy $(TargetDir)*.exe $(SolutionDir)_bin_release
-if "$(OS)" == "Windows_NT"  if "$(ConfigurationName)" == "Release" if exist $(SolutionDir)_bin_release copy $(TargetDir)*.dll $(SolutionDir)_bin_release
-if "$(OS)" == "Unix"  if "$(ConfigurationName)" == "Debug" if exist $(SolutionDir)_bin_debug cp $(TargetDir)*.exe $(SolutionDir)_bin_debug
-if "$(OS)" == "Unix"  if "$(ConfigurationName)" == "Debug" if exist $(SolutionDir)_bin_debug cp $(TargetDir)*.dll $(SolutionDir)_bin_debug
-if "$(OS)" == "Unix"  if "$(ConfigurationName)" == "Release" if exist $(SolutionDir)_bin_release cp $(TargetDir)*.exe $(SolutionDir)_bin_release
-if "$(OS)" == "Unix"  if "$(ConfigurationName)" == "Release" if exist $(SolutionDir)_bin_release cp $(TargetDir)*.dll $(SolutionDir)_bin_release
+    <PostBuildEvent>if "$(OS)" == "Windows_NT"  if "$(ConfigurationName)" == "Debug" if exist "$(SolutionDir)_bin_debug" copy "$(TargetDir)*.exe" "$(SolutionDir)_bin_debug"
+if "$(OS)" == "Windows_NT"  if "$(ConfigurationName)" == "Debug" if exist "$(SolutionDir)_bin_debug" copy "$(TargetDir)*.dll" "$(SolutionDir)_bin_debug"
+if "$(OS)" == "Windows_NT"  if "$(ConfigurationName)" == "Release" if exist "$(SolutionDir)_bin_release" copy "$(TargetDir)*.exe" "$(SolutionDir)_bin_release"
+if "$(OS)" == "Windows_NT"  if "$(ConfigurationName)" == "Release" if exist "$(SolutionDir)_bin_release" copy "$(TargetDir)*.dll" "$(SolutionDir)_bin_release"
+if "$(OS)" == "Unix"  if "$(ConfigurationName)" == "Debug" if exist "$(SolutionDir)_bin_debug" cp "$(TargetDir)*.exe" "$(SolutionDir)_bin_debug"
+if "$(OS)" == "Unix"  if "$(ConfigurationName)" == "Debug" if exist "$(SolutionDir)_bin_debug" cp "$(TargetDir)*.dll" "$(SolutionDir)_bin_debug"
+if "$(OS)" == "Unix"  if "$(ConfigurationName)" == "Release" if exist "$(SolutionDir)_bin_release" cp "$(TargetDir)*.exe" "$(SolutionDir)_bin_release"
+if "$(OS)" == "Unix"  if "$(ConfigurationName)" == "Release" if exist "$(SolutionDir)_bin_release" cp "$(TargetDir)*.dll" "$(SolutionDir)_bin_release"
 </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Campaigns/Scenarios/BasicScenarios/BasicScenarios.csproj
+++ b/Campaigns/Scenarios/BasicScenarios/BasicScenarios.csproj
@@ -69,7 +69,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "$(OS)" == "Windows_NT" copy $(TargetPath) $(SolutionDir)data\plugins
-if "$(OS)" == "Unix" cp $(TargetPath) $(SolutionDir)data\plugins</PostBuildEvent>
+    <PostBuildEvent>if "$(OS)" == "Windows_NT" copy "$(TargetPath)" "$(SolutionDir)data\plugins"
+if "$(OS)" == "Unix" cp "$(TargetPath)" "$(SolutionDir)data\plugins"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Campaigns/Standard/Standard.csproj
+++ b/Campaigns/Standard/Standard.csproj
@@ -104,7 +104,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "$(OS)" == "Windows_NT" copy $(TargetPath) $(SolutionDir)data\plugins
-if "$(OS)" == "Unix" cp $(TargetPath) $(SolutionDir)data\plugins</PostBuildEvent>
+    <PostBuildEvent>if "$(OS)" == "Windows_NT" copy "$(TargetPath)" "$(SolutionDir)data\plugins"
+if "$(OS)" == "Unix" cp "$(TargetPath)" "$(SolutionDir)data\plugins"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
When any of the paths used in the post-build event contains spaces, the post-build will fail, since the path will be splitted by the space and it will be treated as several different arguments for the copy command.